### PR TITLE
add more functions and options to the current api

### DIFF
--- a/src/eos.jl
+++ b/src/eos.jl
@@ -100,11 +100,11 @@ function mixture_compressibility_factor(eos::AbstractCubicEOS, cond,
     return r
 end
 
-minimum_allowable_root(eos::AbstractCubicEOS, forces, scalars, phase) = scalars.B
+minimum_allowable_root(eos::AbstractCubicEOS, forces, scalars) = scalars.B
 minimum_allowable_root(eos, forces, scalars) = 1e-16
 
-@inline pick_root(eos, roots::Real, cond, forces, scalars) = roots
-function pick_root(eos, roots, cond, forces, scalars)
+@inline pick_root(eos, roots::Real, cond, forces, scalars, phase = :unknown) = roots
+function pick_root(eos, roots, cond, forces, scalars, phase = :unknown)
     r_ϵ = minimum_allowable_root(eos, forces, scalars)
     max_r = maximum(roots)
     min_r = minimum((x) -> x > r_ϵ ? x : Inf, roots)

--- a/src/eos.jl
+++ b/src/eos.jl
@@ -110,9 +110,9 @@ function pick_root(eos, roots, cond, forces, scalars)
     min_r = minimum((x) -> x > r_ϵ ? x : Inf, roots)
     if min_r == max_r
         r = min_r
-    elseif phase = :liquid
+    elseif phase == :liquid
         r = min_r
-    elseif phase = :vapor
+    elseif phase == :vapor
         r = max_r
     else
         function Gibbs(Z)

--- a/src/eos.jl
+++ b/src/eos.jl
@@ -369,8 +369,15 @@ Returns the list of component names for the input equation of state)
 component_names(eos::AbstractEOS) = component_names(eos.mixture)
 component_names(mixture::MultiComponentMixture) = mixture.component_names
 
+"""
+    eostype(eos::AbstractEOS)
+Returns the underlying EOS type.
+"""
+eostype(eos::AbstractEOS) = eos.type
+
 function Base.summary(eos::AbstractEOS)
     n = number_of_components(eos)
     cnames = join(component_names(eos), ", ")
-    return "$(eos.type) EOS with $n components: $cnames"
+    return "$(eostype(eos)) EOS with $n components: $cnames"
 end
+

--- a/src/eos.jl
+++ b/src/eos.jl
@@ -372,5 +372,5 @@ component_names(mixture::MultiComponentMixture) = mixture.component_names
 function Base.summary(eos::AbstractEOS)
     n = number_of_components(eos)
     cnames = join(component_names(eos), ", ")
-    "$(eos.type) EOS with $n components: $cnames")
+    return "$(eos.type) EOS with $n components: $cnames"
 end

--- a/src/flash.jl
+++ b/src/flash.jl
@@ -247,8 +247,8 @@ function ssi!(K, p::F, T::F, x, y, z, V::F, eos, forces) where {F<:Real}
     liquid = (p = p, T = T, z = x)
     vapor = (p = p, T = T, z = y)
 
-    Z_l, s_l = prep(eos, liquid, forces)
-    Z_v, s_v = prep(eos, vapor, forces)
+    Z_l, s_l = prep(eos, liquid, forces,:liquid)
+    Z_v, s_v = prep(eos, vapor, forces,:vapor)
 
     ϵ = zero(F)
     @inbounds for c in eachindex(K)
@@ -366,7 +366,9 @@ function flash_update!(K, storage, type::SSINewtonFlash, eos, cond, forces, V, i
     end
 end
 
-function prep(eos, cond, forces)
+#the phase::Symbol argument is not used here, as cubics normally don't require this.
+#however, EOS that require iterative volume calculations require specifying a phase.
+function prep(eos, cond, forces,phase = :unknown)
     s = force_scalars(eos, cond, forces)
     Z = mixture_compressibility_factor(eos, cond, forces, s)
     return (Z, s)
@@ -378,8 +380,8 @@ function update_flash_jacobian!(J, r, eos, p, T, z, x, y, V, forces)
     liquid = (p = p, T = T, z = x)
     vapor = (p = p, T = T, z = y)
 
-    Z_l, s_l = prep(eos, liquid, forces)
-    Z_v, s_v = prep(eos, vapor, forces)
+    Z_l, s_l = prep(eos, liquid, forces,:liquid)
+    Z_v, s_v = prep(eos, vapor, forces,:vapor)
 
     if isa(V, ForwardDiff.Dual)
         np = length(V.partials)

--- a/src/flash.jl
+++ b/src/flash.jl
@@ -370,7 +370,7 @@ end
 #however, EOS that require iterative volume calculations require specifying a phase.
 function prep(eos, cond, forces,phase = :unknown)
     s = force_scalars(eos, cond, forces)
-    Z = mixture_compressibility_factor(eos, cond, forces, s)
+    Z = mixture_compressibility_factor(eos, cond, forces, s, phase)
     return (Z, s)
 end
 

--- a/src/flow_coupler.jl
+++ b/src/flow_coupler.jl
@@ -178,3 +178,20 @@ division for mobilities etc. safe.
     end
     return (μ_l = l::T, μ_v = v::T)
 end
+
+"""
+    molar_masses(eos)
+
+Returns a list of molecular weights (in kg/mol) for each component present in the input equation of state)
+"""
+function molar_masses(eos)
+    return map((x) -> x.mw, eos.mixture.properties)
+end
+"""
+    component_names(eos)
+
+Returns the list of component names for the input equation of state)
+"""
+function component_names(eos)
+    return eos.mixture.mixture.component_names
+end

--- a/src/flow_coupler.jl
+++ b/src/flow_coupler.jl
@@ -179,19 +179,3 @@ division for mobilities etc. safe.
     return (μ_l = l::T, μ_v = v::T)
 end
 
-"""
-    molar_masses(eos)
-
-Returns a list of molecular weights (in kg/mol) for each component present in the input equation of state)
-"""
-function molar_masses(eos)
-    return map((x) -> x.mw, eos.mixture.properties)
-end
-"""
-    component_names(eos)
-
-Returns the list of component names for the input equation of state)
-"""
-function component_names(eos)
-    return eos.mixture.mixture.component_names
-end

--- a/src/kvalues.jl
+++ b/src/kvalues.jl
@@ -19,7 +19,7 @@ end
 
 Update a vector K in-place with K-values from `wilson_estimate`.
 """
-function wilson_estimate!(K::AbstractVector{R}, props, p::R, T::R) where R<:Real
+function wilson_estimate!(K::AbstractVector{R}, props::Union{Tuple,AbstractVector}, p::R, T::R) where R<:Real
     @inbounds for i in eachindex(K)
         K[i] = wilson_estimate(props[i], p, T)::R
     end

--- a/src/kvalues.jl
+++ b/src/kvalues.jl
@@ -25,14 +25,22 @@ function wilson_estimate!(K::AbstractVector{R}, props, p::R, T::R) where R<:Real
     end
 end
 
+function wilson_estimate!(K::AbstractVector{R}, eos::AbstractEOS, p::R, T::R) where R<:Real
+    return wilson_estimate!(K, eos.mixture, p, T)
+end
+
+function wilson_estimate!(K::AbstractVector{R}, mixture::MultiComponentMixture, p, T) where R<:Real
+    wilson_estimate!(K, mixture.properties, p, T)
+end
+
 """
     wilson_estimate(properties, p, T)
 
 Create vector of K-values that holds the `wilson_estimate` for each species.
 """
-function wilson_estimate(mixture::MultiComponentMixture, p, T)
-    K = zeros(number_of_components(mixture))
-    wilson_estimate!(K, mixture.properties, p, T)
+function wilson_estimate(eos, p, T)
+    K = zeros(number_of_components(eos))
+    wilson_estimate!(K, mixture, p, T)
     return K
 end
 
@@ -52,4 +60,4 @@ end
 
 In-place version of `initial_guess_K`.
 """
-initial_guess_K!(K, eos, cond) = wilson_estimate!(K, eos.mixture.properties, cond.p, cond.T)
+initial_guess_K!(K, eos, cond) = wilson_estimate!(K, eos, cond.p, cond.T)

--- a/src/stability.jl
+++ b/src/stability.jl
@@ -22,8 +22,6 @@ function stability_2ph!(storage, K, eos, c; verbose = false, kwarg...)
     vapor = (p = p, T = T, z = y)
     # Update fugacities for current conditions used in both tests
     mixture_fugacities!(f_z, eos, c, forces)
-    props = eos.mixture.properties
-
     wilson_estimate!(K, eos, p, T)
     stable_vapor, i_v = michelsen_test!(vapor, f_z, f_xy, vapor.z, z, K, eos, c, forces, Val(true); kwarg...)
     wilson_estimate!(K, eos, p, T)

--- a/src/stability.jl
+++ b/src/stability.jl
@@ -24,9 +24,9 @@ function stability_2ph!(storage, K, eos, c; verbose = false, kwarg...)
     mixture_fugacities!(f_z, eos, c, forces)
     props = eos.mixture.properties
 
-    wilson_estimate!(K, props, p, T)
+    wilson_estimate!(K, eos, p, T)
     stable_vapor, i_v = michelsen_test!(vapor, f_z, f_xy, vapor.z, z, K, eos, c, forces, Val(true); kwarg...)
-    wilson_estimate!(K, props, p, T)
+    wilson_estimate!(K, eos, p, T)
     stable_liquid, i_l = michelsen_test!(liquid, f_z, f_xy, liquid.z, z, K, eos, c, forces, Val(false); kwarg...)
     stable = stable_vapor && stable_liquid
     if !stable

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,7 +10,7 @@ Li's method for single-phase labeling of a mixture. Estimate of pure vapor/liqui
 
 Returns a vapor fraction that is either 1.0 (=pure vapor) or 0.0 (=pure liquid).
 """
-function single_phase_label(mixture, cond)
+function single_phase_label(mixture::MultiComponentMixture, cond)
     # Li's method for phase labeling.
     z = cond.z
     T_c = 0.0
@@ -23,6 +23,8 @@ function single_phase_label(mixture, cond)
     T_c /= V_c
     return Float64(cond.T > T_c)
 end
+
+single_phase_label(eos::AbstractEOS,cond) = single_phase_label(eos.mixture,cond)
 
 """
     lbc_viscosity(eos, p, T, ph; <keyword arguments>)


### PR DESCRIPTION
the changes are the following:
- new function: `component_names`, returns a list containing the component names
- new function: `molar_masses`, returns a list with the molar masses (in kg/mol)
- new option: `mixture_compressibility_factor` accepts an optional `phase::Symbol` argument, that allows to skip the gibbs calculation if the phase is specified. the same optional argument is added to `prep`
- new function: `Base.summary` (is used while showing `MultiPhaseCompositionalSystemLV`)
- new options `wilson_estimate` and `wilson_estimate!` now can be called with `eos::AbstractEOS` and `mixture::MulticomponentMixture`